### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **Jekyll static site** (an academic homepage) served via the `github-pages`
+gem and hosted on GitHub Pages. There is no backend, database, or API — the whole product is one
+static-site build served by a single dev server.
+
+### Services
+
+| Service | Command | Notes |
+| --- | --- | --- |
+| Jekyll dev server | `bundle exec jekyll serve` | Builds the site and serves it (WebRick) on `http://localhost:4000`. This is the entire product. |
+
+There are no automated tests or lint tooling configured. "Build" == `bundle exec jekyll build`.
+
+### Non-obvious gotchas
+
+- **`jekyll serve` clobbers the committed `docs/` folder.** `_config.yml` sets `destination: docs`,
+  and `docs/` is the checked-in GitHub Pages output. Running `serve`/`build` regenerates `docs/`
+  (including *deleting* `docs/CNAME`, which is not part of the source), producing a large, unwanted
+  diff. To preview locally without touching the tracked output, serve to a throwaway destination:
+  `bundle exec jekyll serve --destination /tmp/_site`. Do **not** commit regenerated `docs/` changes
+  unless you are intentionally re-publishing the site.
+- Ruby is 3.2 (Ubuntu system Ruby). `_plugins/ruby4_compat.rb` is a shim that restores
+  `tainted?`/`untaint` for Ruby 3.4+, so builds also work on newer Ruby.
+- Gems are installed to a bundler path **outside** the repo (`~/.bundle-jekyll`, set via a global
+  `bundle config`). This is deliberate: installing into `vendor/bundle` inside the repo makes Jekyll
+  scan gem files and fail the build on a template file. Keep gems out of the working tree.
+- `Gemfile.lock` is gitignored, so `bundle install` resolves fresh each time.
+- `_config.yml` is **not** hot-reloaded by `jekyll serve`; restart the server after editing it.
+- Node/npm is only needed for the optional `update_bootstrap.sh` asset-refresh helper, not for
+  normal builds.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Jekyll / GitHub Pages academic homepage so a Cloud Agent can build, serve, and preview the site.

This PR only adds `AGENTS.md` with durable, non-obvious setup notes for future agents. No application code is changed.

## Environment

- **Stack:** Jekyll static site via the `github-pages` gem (Ruby 3.2), Bootstrap 4 / jQuery vendored assets. No backend/database.
- **Install:** `bundle install` (gems installed to a bundler path outside the repo to avoid Jekyll scanning `vendor/bundle`).
- **Run (dev):** `bundle exec jekyll serve` → `http://localhost:4000`.

## Notable gotcha documented

`jekyll serve`/`build` regenerates the tracked `docs/` output (`destination: docs`), producing a large unwanted diff and deleting `docs/CNAME`. Use `bundle exec jekyll serve --destination /tmp/_site` to preview without clobbering the committed output.

## Verification

Started the dev server and confirmed the homepage serves correctly (HTTP 200, renders the academic homepage).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5d5b06c-23cf-42e9-b274-0ced5c590c0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5d5b06c-23cf-42e9-b274-0ced5c590c0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

